### PR TITLE
fixed issues in rollbar to unique keys

### DIFF
--- a/app/adapters/jira/jira_issue_adapter.rb
+++ b/app/adapters/jira/jira_issue_adapter.rb
@@ -96,14 +96,14 @@ module Jira
 
     def create_from_transition(demand, from_stage_id, from_transition_date)
       stage_from = demand.project.stages.find_by(integration_id: from_stage_id)
-      DemandTransition.where(demand: demand, stage: stage_from, last_time_in: from_transition_date).first_or_create
+      DemandTransition.find_or_create_by(demand: demand, stage: stage_from, last_time_in: from_transition_date)
     end
 
     def create_to_transition(demand, from_transistion, to_stage_id, to_transition_date)
       from_transistion.update(last_time_out: to_transition_date)
 
       stage_to = demand.project.stages.find_by(integration_id: to_stage_id)
-      DemandTransition.where(demand: demand, stage: stage_to, last_time_in: to_transition_date).first_or_create
+      DemandTransition.find_or_create_by(demand: demand, stage: stage_to, last_time_in: to_transition_date)
     end
 
     def read_comments(demand, jira_issue_attrs)
@@ -168,8 +168,10 @@ module Jira
     end
 
     def read_assigned_responsibles(demand, team, history_date, responsible_name)
-      team_member = TeamMember.where(company: team.company).where('lower(name) = :member_name', member_name: responsible_name.downcase).first_or_initialize
-      assignment = ItemAssignment.where(demand: demand, team_member: team_member, finish_time: nil).first_or_initialize
+      team_member = TeamMember.where(company: team.company).where('lower(name) = :member_name', member_name: responsible_name.downcase).first
+      team_member = TeamMember.create(company: team.company, name: responsible_name.downcase) if team_member.blank?
+
+      assignment = ItemAssignment.find_or_initialize_by(demand: demand, team_member: team_member, finish_time: nil)
       assignment.update(start_time: history_date) unless assignment.persisted?
     end
 

--- a/app/adapters/jira/jira_issue_adapter.rb
+++ b/app/adapters/jira/jira_issue_adapter.rb
@@ -64,8 +64,11 @@ module Jira
     def read_transitions!(demand, issue_changelog)
       demand.demand_transitions.map(&:destroy)
       backlog_transition_date = demand.created_date
-      backlog_stage = demand.first_stage_in_the_flow.integration_id
-      create_from_transition(demand, backlog_stage, backlog_transition_date)
+
+      first_stage_in_the_flow = demand.first_stage_in_the_flow
+      return if first_stage_in_the_flow.blank?
+
+      create_from_transition(demand, first_stage_in_the_flow.integration_id, backlog_transition_date)
 
       read_transition_history(demand, issue_changelog)
     end

--- a/app/models/demand.rb
+++ b/app/models/demand.rb
@@ -237,7 +237,10 @@ class Demand < ApplicationRecord
   end
 
   def first_stage_in_the_flow
-    team.stages.where('stages.order >= 0').order(:order).first
+    first_stage = team.stages.where('stages.order >= 0').order(:order).first
+    return first_stage if first_stage.present?
+
+    project.stages.where('stages.order >= 0').order(:order).first
   end
 
   private

--- a/spec/adapters/jira/jira_issue_adapter_spec.rb
+++ b/spec/adapters/jira/jira_issue_adapter_spec.rb
@@ -118,9 +118,10 @@ RSpec.describe Jira::JiraIssueAdapter, type: :service do
 
         let!(:jira_issue) { client.Issue.build({ key: '10000', summary: 'foo of bar', fields: { created: '2018-07-03T11:20:18.998-0300', issuetype: { name: 'Bug' }, project: { key: 'foo' }, customfield_10024: [{ name: 'foo' }, { name: 'bar' }] }, changelog: { startAt: 0, maxResults: 2, total: 2, histories: [{ id: '10432', created: '2018-07-06T09:40:43.886-0300', items: [{ field: 'Responsible', fieldId: 'customfield_10024', from: "[#{team_member.name}]", to: "['foo do xpto']", toString: "['foo do xpto']" }] }] } }.with_indifferent_access) }
 
-        it 'creates the demand without members' do
+        it 'creates the demand and creates the member' do
           described_class.instance.process_issue!(jira_account, product, first_project, jira_issue)
-          expect(Demand.last.team_members).to be_empty
+          expect(Demand.last.team_members.size).to eq 1
+          expect(Demand.last.team_members).not_to eq team_member
         end
       end
 

--- a/spec/adapters/jira/jira_issue_adapter_spec.rb
+++ b/spec/adapters/jira/jira_issue_adapter_spec.rb
@@ -357,18 +357,30 @@ RSpec.describe Jira::JiraIssueAdapter, type: :service do
           expect(Demand.last.created_date).to eq Time.zone.parse('2018-07-02T11:20:18.998-0300')
         end
       end
-    end
 
-    context 'with no transitions' do
-      let!(:jira_issue) { client.Issue.build({ key: '10000', fields: { created: '2018-07-02T11:20:18.998-0300', summary: 'foo of bar', issuetype: { name: 'Story' }, customfield_10028: { value: 'Expedite' }, project: { key: 'foo' }, status: { id: backlog.integration_id } }, changelog: { startAt: 0, maxResults: 2, total: 2, histories: [] } }.with_indifferent_access) }
+      context 'with no transitions' do
+        let!(:jira_issue) { client.Issue.build({ key: '10000', fields: { created: '2018-07-02T11:20:18.998-0300', summary: 'foo of bar', issuetype: { name: 'Story' }, customfield_10028: { value: 'Expedite' }, project: { key: 'foo' }, status: { id: backlog.integration_id } }, changelog: { startAt: 0, maxResults: 2, total: 2, histories: [] } }.with_indifferent_access) }
 
-      it 'adds the transition to the status using the created date' do
-        described_class.instance.process_issue!(jira_account, product, first_project, jira_issue)
+        it 'adds the transition to the status using the created date' do
+          described_class.instance.process_issue!(jira_account, product, first_project, jira_issue)
 
-        backlog_updated = backlog.reload
-        expect(backlog_updated.demand_transitions.count).to eq 1
-        expect(backlog_updated.demand_transitions.first.last_time_in).to eq Time.zone.parse('2018-07-02T11:20:18.998-0300')
-        expect(backlog_updated.demand_transitions.first.last_time_out).to eq nil
+          backlog_updated = backlog.reload
+          expect(backlog_updated.demand_transitions.count).to eq 1
+          expect(backlog_updated.demand_transitions.first.last_time_in).to eq Time.zone.parse('2018-07-02T11:20:18.998-0300')
+          expect(backlog_updated.demand_transitions.first.last_time_out).to eq nil
+        end
+      end
+
+      context 'with no stages either in the team nor in the project' do
+        let!(:demand) { Fabricate :demand, external_id: 'xpto do foo' }
+        let!(:project) { Fabricate :project, company: company }
+        let!(:jira_issue) { client.Issue.build({ key: 'xpto do foo', summary: 'foo of bar', fields: { created: '2018-07-02T11:20:18.998-0300', issuetype: { name: 'Story' }, customfield_10028: { value: 'Expedite' }, project: { key: 'foo' }, customfield_10024: [{ name: 'foo' }, { name: 'bar' }] }, changelog: { startAt: 0, maxResults: 2, total: 2, histories: [{ id: '10041', created: '2018-07-09T23:34:47.440-0300', items: [{ field: 'status', from: 'first_stage', to: 'second_stage' }] }, { id: '10040', created: '2018-07-09T22:34:47.440-0300', items: [{ field: 'status', from: 'second_stage', to: 'first_stage' }] }, { id: '10039', created: '2018-07-08T22:34:47.440-0300', items: [{ field: 'status', from: 'first_stage', to: 'second_stage' }] }, { id: '10038', created: '2018-07-06T09:40:43.886-0300', items: [{ field: 'status', from: 'third_stage', to: 'first_stage' }] }, { id: '10055', created: '2018-07-06T09:40:43.886-0300', items: [{ field: 'foo', from: 'third_stage', to: 'first_stage' }] }] } }.with_indifferent_access) }
+
+        it 'creates the demand without the transitions' do
+          described_class.instance.process_issue!(jira_account, product, project, jira_issue)
+          demand_updated = demand.reload
+          expect(demand_updated.demand_transitions).to eq []
+        end
       end
     end
   end

--- a/spec/models/demand_spec.rb
+++ b/spec/models/demand_spec.rb
@@ -878,10 +878,21 @@ RSpec.describe Demand, type: :model do
     let!(:second_stage) { Fabricate :stage, teams: [team], stage_stream: :upstream, order: 1 }
     let!(:third_stage) { Fabricate :stage, teams: [team], stage_stream: :upstream, order: -1 }
 
-    let!(:demand) { Fabricate :demand, team: team }
-    let!(:other_demand) { Fabricate :demand }
+    context 'with stages' do
+      let!(:demand) { Fabricate :demand, team: team }
+      let!(:other_demand) { Fabricate :demand }
 
-    it { expect(demand.first_stage_in_the_flow).to eq first_stage }
-    it { expect(other_demand.first_stage_in_the_flow).to be_nil }
+      it { expect(demand.first_stage_in_the_flow).to eq first_stage }
+      it { expect(other_demand.first_stage_in_the_flow).to be_nil }
+    end
+
+    context 'with no stages' do
+      let!(:project) { Fabricate :project, team: team, stages: [first_stage, second_stage, third_stage] }
+      let!(:demand) { Fabricate :demand, team: team, project: project }
+      let!(:other_demand) { Fabricate :demand }
+
+      it { expect(demand.first_stage_in_the_flow).to eq first_stage }
+      it { expect(other_demand.first_stage_in_the_flow).to be_nil }
+    end
   end
 end


### PR DESCRIPTION
- NoMethodError: undefined method `integration_id' for nil:NilClass

- PG::UniqueViolation: ERROR: duplicate key value violates unique constraint "idx_transitions_unique" DETAIL: Key (demand_id, stage_id, last_time_in)=(10641, 287, 2020-03-24 20:32:11.578) already exists

- NoMethodError: undefined method `working_hours_until' for nil:NilClass

- PG::UniqueViolation: ERROR: duplicate key value violates unique constraint "demand_member_start_time_unique" DETAIL: Key (demand_id, team_member_id, start_time)=(10641, 403, 2020-03-30 20:16:46.681) already exists.